### PR TITLE
Fixes in load progress dialog.

### DIFF
--- a/rtneuron/python/rtneuron/gui/dialogs/Progress.qml
+++ b/rtneuron/python/rtneuron/gui/dialogs/Progress.qml
@@ -22,9 +22,6 @@ import QtQuick 2.4
 
 Rectangle
 {
-    property alias progress: progressBar.value
-    property alias message: messageText.text
-
     opacity: 0.8
     radius: 10
     border.width: 0
@@ -36,6 +33,11 @@ Rectangle
 
     property real fontSize: 12
 
+    function step(message, progress)
+    {
+        progressBar.value = progress
+        messageText.text = message
+    }
 
     Column
     {

--- a/rtneuron/python/rtneuron/gui/dialogs/loadDialog.py
+++ b/rtneuron/python/rtneuron/gui/dialogs/loadDialog.py
@@ -67,6 +67,10 @@ class LoadDialog(QMLBaseDialog):
             self.dialog.invalidSimulation(config_file, error.args[0])
             return
 
+        gids = simulation.gids()
+        self.done.emit(simulation, gids, display_mode)
+        return
+
         targets = targets.lstrip().rstrip()
 
         if targets == "":

--- a/rtneuron/python/rtneuron/gui/dialogs/progress.py
+++ b/rtneuron/python/rtneuron/gui/dialogs/progress.py
@@ -27,10 +27,15 @@ class Progress(QMLBaseDialog):
 
     done = QtCore.pyqtSignal(int)
 
+    # Internal signal used to forward the progress signal from non-GUI threads
+    # to the GUI thread
+    _step = QtCore.pyqtSignal(str, float)
+
     def __init__(self, parent):
         super(Progress, self).__init__(parent, "dialogs/Progress.qml")
 
         self._pass = 0
+        self._step.connect(self.dialog.step)
 
     def set_message(self, msg):
 
@@ -38,8 +43,7 @@ class Progress(QMLBaseDialog):
 
     def step(self, msg, size, total):
 
-        self.dialog.setProperty("progress", size/float(total))
-        self.dialog.setProperty("message", msg)
+        self._step.emit(msg, size/float(total))
 
         if size == total:
             self._pass += 1

--- a/rtneuron/python/rtneuron/gui/loaderGUI.py
+++ b/rtneuron/python/rtneuron/gui/loaderGUI.py
@@ -77,8 +77,6 @@ class LoaderGUI(BaseGUI):
             attributes.mode = _rtneuron.RepresentationMode.WHOLE_NEURON
 
         scene.addNeurons(gids, attributes)
-        view.computeHomePosition() # We need to do this because we
-                                   # have disabled the auto-home feature.
 
         # If something was typed in the loader dialog the base overlay has
         # lost the focus. Returning the focus because otherwise key presses
@@ -88,7 +86,12 @@ class LoaderGUI(BaseGUI):
     def _on_progress_done(self, pass_number):
 
         if pass_number == 2:
+
             view = _rtneuron.engine.views[0]
+
+            view.computeHomePosition() # We need to do this because the auto
+                                       # home position is disabled
+
             scene = view.scene
             scene.progress.disconnect(self.progress.step)
             self.progress.close()


### PR DESCRIPTION
Progress signal was not properly forwarded to the application thread.
Moved home position resetting to a point where it doesn't interfere with
scene creation.